### PR TITLE
Update dependencies to fix problem with python > python3.5

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,4 +20,6 @@ dependencies:
     tags: ["cjdns", "cjdns-install"]
 
   - role: "jtyr.config_encoder_filters"
+    src: https://github.com/jtyr/ansible-config_encoder_filters
+    scm: git
     tags: ["cjdns", "cjdns-configure"]


### PR DESCRIPTION
My playbooks ended up failing with

```
{"changed": false, "msg": "AttributeError: 'dict' object has no attribute 'iteritems'"}
```

when running [earlier fork of role role](https://github.com/kevit/ansible-role-cjdns). I traced this down to python version differences and the problem had been fixed in the upstream of one of the depencencies used. 

This PR changes the dependency to use upstream of [jtyr/ansible-config_encoder_filters](https://github.com/jtyr/ansible-config_encoder_filters) instead of the old version from ansible galaxy.